### PR TITLE
join hintを付加してbroadcastとshuffleどちらが選ばれるかのテスト追加

### DIFF
--- a/src/main/scala/jp/cedretaber/minispark/JoinExplainTest.scala
+++ b/src/main/scala/jp/cedretaber/minispark/JoinExplainTest.scala
@@ -1,0 +1,58 @@
+package jp.cedretaber.minispark
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.extensions.functions.{no_broadcast_hash, prefer_shuffle_hash, shuffle_hash}
+import org.apache.spark.sql.functions.broadcast
+
+object JoinExplainTest {
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession.builder()
+      .appName("MiniSpark")
+      .master("local[*]")
+      .getOrCreate()
+
+    val users = spark.read.option("header", true).csv("src/main/resources/users.csv")
+    users.show()
+    val langs = spark.read.option("header", true).csv("src/main/resources/langs.csv")
+    langs.show()
+    val relations = spark.read.option("header", true).csv("src/main/resources/user_langs.csv")
+    relations.show()
+
+    // BroadcastHashJoin になった
+    val result = users
+      .join(relations, users("id") === relations("user_id"))
+      .join(langs, relations("lang_id") === langs("id"))
+    result.show()
+    result.explain()
+
+    // BroadcastHashJoin になった
+    val broadcastResult = users
+      .join(broadcast(relations), users("id") === relations("user_id"))
+      .join(broadcast(langs), relations("lang_id") === langs("id"))
+    broadcastResult.show()
+    broadcastResult.explain()
+
+    // BroadcastHashJoin になった
+    val noBroadcastHashResult = users
+      .join(no_broadcast_hash(relations), users("id") === relations("user_id"))
+      .join(no_broadcast_hash(langs), relations("lang_id") === langs("id"))
+    noBroadcastHashResult.show()
+    noBroadcastHashResult.explain()
+
+    // BroadcastHashJoin になった
+    val preferShuffleHashResult = users
+      .join(prefer_shuffle_hash(relations), users("id") === relations("user_id"))
+      .join(prefer_shuffle_hash(langs), relations("lang_id") === langs("id"))
+    preferShuffleHashResult.show()
+    preferShuffleHashResult.explain()
+
+    // これだけは ShuffledHashJoin になった
+    val shuffleHashResult = users
+      .join(shuffle_hash(relations), users("id") === relations("user_id"))
+      .join(shuffle_hash(langs), relations("lang_id") === langs("id"))
+    shuffleHashResult.show()
+    shuffleHashResult.explain()
+
+    spark.stop()
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/extensions/functions.scala
+++ b/src/main/scala/org/apache/spark/sql/extensions/functions.scala
@@ -1,0 +1,26 @@
+package org.apache.spark.sql.extensions
+
+import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.catalyst.plans.logical._
+
+/**
+ * join hintを付加する関数群
+ *
+ * @note DataSet#apply が package private なので org.apache.spark.sql 以下に置いている
+ */
+object functions {
+  def no_broadcast_hash[T](df: Dataset[T]): Dataset[T] = {
+    Dataset[T](df.sparkSession,
+      ResolvedHint(df.logicalPlan, HintInfo(strategy = Some(NO_BROADCAST_HASH))))(df.exprEnc)
+  }
+
+  def prefer_shuffle_hash[T](df: Dataset[T]): Dataset[T] = {
+    Dataset[T](df.sparkSession,
+      ResolvedHint(df.logicalPlan, HintInfo(strategy = Some(PREFER_SHUFFLE_HASH))))(df.exprEnc)
+  }
+
+  def shuffle_hash[T](df: Dataset[T]): Dataset[T] = {
+    Dataset[T](df.sparkSession,
+      ResolvedHint(df.logicalPlan, HintInfo(strategy = Some(SHUFFLE_HASH))))(df.exprEnc)
+  }
+}


### PR DESCRIPTION
join hintを追加してbroadcastとは逆にshuffle joinを強制できないかやってみた
またexplainで様子を見てみた

### 実行方法

```
$ spark-submit --class=jp.cedretaber.minispark.JoinExplainTest --master="local[*]" target/scala-2.13/minispark_2.13-0.1.0-SNAPSHOT.jar
```