### PR TITLE
heavy hittersの計算を追加した

### DIFF
--- a/src/main/scala/jp/cedretaber/minispark/FlowJoinTest.scala
+++ b/src/main/scala/jp/cedretaber/minispark/FlowJoinTest.scala
@@ -6,6 +6,7 @@ import org.apache.spark.sql.{Row, SparkSession}
 
 import scala.jdk.CollectionConverters._
 
+// 各種splitのサンプル
 object FlowJoinTest {
   def main(args: Array[String]): Unit = {
     val spark = SparkSession.builder()

--- a/src/main/scala/jp/cedretaber/minispark/FlowJoinTest.scala
+++ b/src/main/scala/jp/cedretaber/minispark/FlowJoinTest.scala
@@ -1,0 +1,64 @@
+package jp.cedretaber.minispark
+
+
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.apache.spark.sql.{Row, SparkSession}
+
+import scala.jdk.CollectionConverters._
+
+object FlowJoinTest {
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession.builder()
+      .appName("MiniSpark")
+      .master("local[*]")
+      .getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    val users = spark.read.option("header", true).csv("src/main/resources/users.csv")
+    users.show()
+    val langs = spark.read.option("header", true).csv("src/main/resources/langs.csv")
+    langs.show()
+    val relations = spark.read.option("header", true).csv("src/main/resources/user_langs.csv")
+    relations.show()
+
+    {
+      import jp.cedretaber.minispark.flowJoinStrategy.IteratorSplitStrategy._
+
+      val result = users
+        .flowJoin[String](relations, "id", "user_id", Array("1", "3", "4"))
+        .flowJoin[String](langs, "lang_id", "id", Array("1", "5"))
+      result.show()
+    }
+
+    {
+      import jp.cedretaber.minispark.flowJoinStrategy.GroupBySplitStrategy._
+
+      val result = users
+        .flowJoin[String](relations, "id", "user_id", spark.sparkContext.broadcast(Set("1", "3", "4")))
+        .flowJoin[String](langs, "lang_id", "id", spark.sparkContext.broadcast(Set("1", "5")))
+      result.show()
+    }
+
+    {
+      import jp.cedretaber.minispark.flowJoinStrategy.FilterSplitStrategy._
+
+      val result = users
+        .flowJoin[String](relations, "id", "user_id", spark.sparkContext.broadcast(Set("1", "3", "4")))
+        .flowJoin[String](langs, "lang_id", "id", spark.sparkContext.broadcast(Set("1", "5")))
+      result.show()
+    }
+
+    {
+      import jp.cedretaber.minispark.flowJoinStrategy.JoinSplitStrategy._
+
+      val schema = StructType(Seq(StructField("id", StringType)))
+
+      val result = users
+        .flowJoin[String](relations, "id", "user_id", spark.createDataFrame(Seq("1", "3", "4").map(Row(_: _*)).asJava, schema))
+        .flowJoin[String](langs, "lang_id", "id", spark.createDataFrame(Seq("1", "5").map(Row(_: _*)).asJava, schema))
+      result.show()
+    }
+
+    spark.stop()
+  }
+}

--- a/src/main/scala/jp/cedretaber/minispark/FlowJoinTest2.scala
+++ b/src/main/scala/jp/cedretaber/minispark/FlowJoinTest2.scala
@@ -1,0 +1,36 @@
+package jp.cedretaber.minispark
+
+import jp.cedretaber.minispark.heavyHitterStatistics.StatisticsV2
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.apache.spark.sql.{Row, SparkSession}
+
+import scala.jdk.CollectionConverters._
+
+// heavy hitters の計算を与えるサンプル
+object FlowJoinTest2 {
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession.builder()
+      .appName("MiniSpark")
+      .master("local[*]")
+      .getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    val users = spark.read.option("header", true).csv("src/main/resources/users.csv")
+    users.show()
+    val langs = spark.read.option("header", true).csv("src/main/resources/langs.csv")
+    langs.show()
+    val relations = spark.read.option("header", true).csv("src/main/resources/user_langs.csv")
+    relations.show()
+
+    {
+      import jp.cedretaber.minispark.flowJoinStrategy.JoinSplitStrategy._
+
+      val result = users
+        .flowJoin[String](relations, "id", "user_id", StatisticsV2)
+        .flowJoin[String](langs, "lang_id", "id", StatisticsV2)
+      result.show()
+    }
+
+    spark.stop()
+  }
+}

--- a/src/main/scala/jp/cedretaber/minispark/flowJoinStrategy/FilterSplitStrategy.scala
+++ b/src/main/scala/jp/cedretaber/minispark/flowJoinStrategy/FilterSplitStrategy.scala
@@ -1,0 +1,41 @@
+package jp.cedretaber.minispark.flowJoinStrategy
+
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.extensions.functions.shuffle_hash
+import org.apache.spark.sql.functions.broadcast
+
+object FilterSplitStrategy {
+  private def split[T](table: DataFrame, colName: String, heavyHitters: Broadcast[Set[T]]): (DataFrame, DataFrame) = {
+    val idx = table.schema.fieldIndex(colName)
+    (
+      table.filter(row => heavyHitters.value(row.getAs[T](idx))),
+      table.filter(row => !heavyHitters.value(row.getAs[T](idx)))
+    )
+  }
+
+  def exec[T](
+    left: DataFrame,
+    right: DataFrame,
+    leftColName: String,
+    rightColName: String,
+    heavyHitters: Broadcast[Set[T]]
+  ): DataFrame = {
+    val (leftBr, leftSc) = split(left, leftColName, heavyHitters)
+    val (rightBr, rightSc) = split(right, rightColName, heavyHitters)
+
+    val sc = leftSc.join(shuffle_hash(rightSc), leftSc(leftColName) === rightSc(rightColName))
+    val br = leftBr.join(broadcast(rightBr), leftBr(leftColName) === rightBr(rightColName))
+
+    sc.union(br)
+  }
+
+  implicit class extension(val left: DataFrame) {
+    def flowJoin[T](
+      right: DataFrame,
+      leftColName: String,
+      rightColName: String,
+      heavyHitters: Broadcast[Set[T]]
+    ): DataFrame = exec(left, right, leftColName, rightColName, heavyHitters)
+  }
+}

--- a/src/main/scala/jp/cedretaber/minispark/flowJoinStrategy/GroupBySplitStrategy.scala
+++ b/src/main/scala/jp/cedretaber/minispark/flowJoinStrategy/GroupBySplitStrategy.scala
@@ -1,0 +1,45 @@
+package jp.cedretaber.minispark.flowJoinStrategy
+
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.extensions.functions.shuffle_hash
+import org.apache.spark.sql.functions.broadcast
+
+import scala.jdk.CollectionConverters._
+
+object GroupBySplitStrategy {
+  private def split[T](table: DataFrame, colName: String, heavyHitters: Broadcast[Set[T]]): (DataFrame, DataFrame) = {
+    val idx = table.schema.fieldIndex(colName)
+    val groups = table.rdd.groupBy(row => heavyHitters.value(row.getAs[T](idx))).collectAsMap()
+    val sparkSession = table.sparkSession
+    (
+      sparkSession.createDataFrame(groups(true).toList.asJava, table.schema),
+      sparkSession.createDataFrame(groups(false).toList.asJava, table.schema)
+    )
+  }
+
+  def exec[T](
+    left: DataFrame,
+    right: DataFrame,
+    leftColName: String,
+    rightColName: String,
+    heavyHitters: Broadcast[Set[T]]
+  ): DataFrame = {
+    val (leftBr, leftSc) = split(left, leftColName, heavyHitters)
+    val (rightBr, rightSc) = split(right, rightColName, heavyHitters)
+
+    val sc = leftSc.join(shuffle_hash(rightSc), leftSc(leftColName) === rightSc(rightColName))
+    val br = leftBr.join(broadcast(rightBr), leftBr(leftColName) === rightBr(rightColName))
+
+    sc.union(br)
+  }
+
+  implicit class extension(val left: DataFrame) {
+    def flowJoin[T](
+      right: DataFrame,
+      leftColName: String,
+      rightColName: String,
+      heavyHitters: Broadcast[Set[T]]
+    ): DataFrame = exec(left, right, leftColName, rightColName, heavyHitters)
+  }
+}

--- a/src/main/scala/jp/cedretaber/minispark/flowJoinStrategy/IteratorSplitStrategy.scala
+++ b/src/main/scala/jp/cedretaber/minispark/flowJoinStrategy/IteratorSplitStrategy.scala
@@ -1,0 +1,63 @@
+package jp.cedretaber.minispark.flowJoinStrategy
+
+import org.apache.spark.sql.extensions.functions.shuffle_hash
+import org.apache.spark.sql.functions.broadcast
+import org.apache.spark.sql.{DataFrame, Row}
+
+import scala.jdk.CollectionConverters._
+import scala.math.Ordering.Implicits._
+
+object IteratorSplitStrategy {
+  private def split[T: Ordering](table: DataFrame, colName: String, heavyHitters: Array[T]): (DataFrame, DataFrame) = {
+    val idx = table.schema.fieldIndex(colName)
+    val brBuilder = Seq.newBuilder[Row]
+    val shBuilder = Seq.newBuilder[Row]
+
+    var heavyHitterIndex = 0
+    for {
+      row <- table.rdd.collect().sortBy(_.getAs[T](idx))
+    } {
+      while (heavyHitterIndex < heavyHitters.length && heavyHitters(heavyHitterIndex) < row.getAs[T](idx)) {
+        heavyHitterIndex += 1
+      }
+
+      if (heavyHitterIndex < heavyHitters.length && heavyHitters(heavyHitterIndex) == row.getAs[T](idx)) {
+        brBuilder += row
+      } else {
+        shBuilder += row
+      }
+    }
+
+    val sparkSession = table.sparkSession
+    (
+      sparkSession.createDataFrame(brBuilder.result().asJava, table.schema),
+      sparkSession.createDataFrame(shBuilder.result().asJava, table.schema)
+    )
+  }
+
+
+  def exec[T: Ordering](
+    left: DataFrame,
+    right: DataFrame,
+    leftColName: String,
+    rightColName: String,
+    heavyHitters: Array[T]
+  ): DataFrame = {
+    val (leftBr, leftSc) = split(left, leftColName, heavyHitters)
+    val (rightBr, rightSc) = split(right, rightColName, heavyHitters)
+
+    val sc = leftSc.join(shuffle_hash(rightSc), leftSc(leftColName) === rightSc(rightColName))
+    val br = leftBr.join(broadcast(rightBr), leftBr(leftColName) === rightBr(rightColName))
+
+    sc.union(br)
+  }
+
+  implicit class extension(val left: DataFrame) {
+    def flowJoin[T: Ordering](
+      right: DataFrame,
+      leftColName: String,
+      rightColName: String,
+      heavyHitters: Array[T]
+    ): DataFrame = exec(left, right, leftColName, rightColName, heavyHitters)
+  }
+}

--- a/src/main/scala/jp/cedretaber/minispark/flowJoinStrategy/JoinSplitStrategy.scala
+++ b/src/main/scala/jp/cedretaber/minispark/flowJoinStrategy/JoinSplitStrategy.scala
@@ -1,0 +1,40 @@
+package jp.cedretaber.minispark.flowJoinStrategy
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.extensions.functions.shuffle_hash
+import org.apache.spark.sql.functions.broadcast
+
+object JoinSplitStrategy {
+  private def split[T](table: DataFrame, colName: String, heavyHitters: DataFrame): (DataFrame, DataFrame) = {
+    val heavyHittersColName = heavyHitters.columns(0)
+    (
+      table.join(heavyHitters, table(colName) === heavyHitters(heavyHittersColName), "left_semi"),
+      table.join(heavyHitters, table(colName) === heavyHitters(heavyHittersColName), "left_anti")
+    )
+  }
+
+  def exec[T](
+    left: DataFrame,
+    right: DataFrame,
+    leftColName: String,
+    rightColName: String,
+    heavyHitters: DataFrame
+  ): DataFrame = {
+    val (leftBr, leftSc) = split(left, leftColName, heavyHitters)
+    val (rightBr, rightSc) = split(right, rightColName, heavyHitters)
+
+    val sc = leftSc.join(shuffle_hash(rightSc), leftSc(leftColName) === rightSc(rightColName))
+    val br = leftBr.join(broadcast(rightBr), leftBr(leftColName) === rightBr(rightColName))
+
+    sc.union(br)
+  }
+
+  implicit class extension(val left: DataFrame) {
+    def flowJoin[T](
+      right: DataFrame,
+      leftColName: String,
+      rightColName: String,
+      heavyHitters: DataFrame
+    ): DataFrame = exec(left, right, leftColName, rightColName, heavyHitters)
+  }
+}

--- a/src/main/scala/jp/cedretaber/minispark/flowJoinStrategy/JoinSplitStrategy.scala
+++ b/src/main/scala/jp/cedretaber/minispark/flowJoinStrategy/JoinSplitStrategy.scala
@@ -1,5 +1,6 @@
 package jp.cedretaber.minispark.flowJoinStrategy
 
+import jp.cedretaber.minispark.heavyHitterStatistics.HeavyHittersStatistics
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.extensions.functions.shuffle_hash
 import org.apache.spark.sql.functions.broadcast
@@ -30,11 +31,25 @@ object JoinSplitStrategy {
   }
 
   implicit class extension(val left: DataFrame) {
+    /**
+     * heavy hitters 外挿版
+     */
     def flowJoin[T](
       right: DataFrame,
       leftColName: String,
       rightColName: String,
       heavyHitters: DataFrame
     ): DataFrame = exec(left, right, leftColName, rightColName, heavyHitters)
+
+    /**
+     * heavy hitters 計算版
+     */
+    def flowJoin[T](
+      right: DataFrame,
+      leftColName: String,
+      rightColName: String,
+      heavyHittersStatistics: HeavyHittersStatistics
+    ): DataFrame =
+      exec(left, right, leftColName, rightColName, heavyHittersStatistics.exec(left, leftColName))
   }
 }

--- a/src/main/scala/jp/cedretaber/minispark/heavyHitterStatistics/HeavyHittersStatistics.scala
+++ b/src/main/scala/jp/cedretaber/minispark/heavyHitterStatistics/HeavyHittersStatistics.scala
@@ -1,0 +1,7 @@
+package jp.cedretaber.minispark.heavyHitterStatistics
+
+import org.apache.spark.sql.DataFrame
+
+trait HeavyHittersStatistics {
+  def exec(left: DataFrame, leftColName: String): DataFrame
+}

--- a/src/main/scala/jp/cedretaber/minispark/heavyHitterStatistics/StatisticsV2.scala
+++ b/src/main/scala/jp/cedretaber/minispark/heavyHitterStatistics/StatisticsV2.scala
@@ -1,0 +1,13 @@
+package jp.cedretaber.minispark.heavyHitterStatistics
+
+import org.apache.spark.sql.DataFrame
+
+object StatisticsV2 extends HeavyHittersStatistics {
+
+  private val THRESHOLD = 4 // worker_instances - 1
+
+  def exec(left: DataFrame, leftColName: String): DataFrame = {
+    val counted = left.groupBy(leftColName).count()
+    counted.filter(counted("count") >= THRESHOLD).select(leftColName)
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/extensions/functions.scala
+++ b/src/main/scala/org/apache/spark/sql/extensions/functions.scala
@@ -1,0 +1,26 @@
+package org.apache.spark.sql.extensions
+
+import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.catalyst.plans.logical._
+
+/**
+ * join hintを付加する関数群
+ *
+ * @note DataSet#apply が package private なので org.apache.spark.sql 以下に置いている
+ */
+object functions {
+  def no_broadcast_hash[T](df: Dataset[T]): Dataset[T] = {
+    Dataset[T](df.sparkSession,
+      ResolvedHint(df.logicalPlan, HintInfo(strategy = Some(NO_BROADCAST_HASH))))(df.exprEnc)
+  }
+
+  def prefer_shuffle_hash[T](df: Dataset[T]): Dataset[T] = {
+    Dataset[T](df.sparkSession,
+      ResolvedHint(df.logicalPlan, HintInfo(strategy = Some(PREFER_SHUFFLE_HASH))))(df.exprEnc)
+  }
+
+  def shuffle_hash[T](df: Dataset[T]): Dataset[T] = {
+    Dataset[T](df.sparkSession,
+      ResolvedHint(df.logicalPlan, HintInfo(strategy = Some(SHUFFLE_HASH))))(df.exprEnc)
+  }
+}


### PR DESCRIPTION
## 概要

#6 にheavy hittersの計算を追加しました。
Statisticsのinstanceを引数として渡すと自力で計算するようになります

## 用意された実装

- StatisticsV2: 単純にleftでの出現数(fan-out)をカウントする

## サンプル実行方法

```
$ spark-submit --class=jp.cedretaber.minispark.FlowJoinTest2 --master="local[*]" target/scala-2.13/minispark_2.13-0.1.0-SNAPSHOT.jar
```